### PR TITLE
feat: adds currentTimeIndicator component to Calendar

### DIFF
--- a/src/Calendar.js
+++ b/src/Calendar.js
@@ -731,6 +731,7 @@ class Calendar extends React.Component {
      *   timeSlotWrapper: MyTimeSlotWrapper,
      *   timeGutterHeader: MyTimeGutterWrapper,
      *   resourceHeader: MyResourceHeader,
+     *   currentTimeIndicator: MyCurrentTimeIndicator,
      *   toolbar: MyToolbar,
      *   agenda: {
      *   	 event: MyAgendaEvent, // with the agenda view use a different component to render events
@@ -763,6 +764,8 @@ class Calendar extends React.Component {
       timeSlotWrapper: PropTypes.elementType,
       timeGutterHeader: PropTypes.elementType,
       resourceHeader: PropTypes.elementType,
+
+      currentTimeIndicator: PropTypes.elementType,
 
       toolbar: PropTypes.elementType,
 

--- a/src/CurrentTimeIndicator.js
+++ b/src/CurrentTimeIndicator.js
@@ -1,0 +1,12 @@
+import PropTypes from 'prop-types'
+import React from 'react'
+
+const CurrentTimeIndicator = ({ position }) => (
+  <div className="rbc-current-time-indicator" style={{ top: `${position}%` }} />
+)
+
+CurrentTimeIndicator.propTypes = {
+  position: PropTypes.number,
+}
+
+export default CurrentTimeIndicator

--- a/src/DayColumn.js
+++ b/src/DayColumn.js
@@ -13,6 +13,7 @@ import TimeSlotGroup from './TimeSlotGroup'
 import TimeGridEvent from './TimeGridEvent'
 import { DayLayoutAlgorithmPropType } from './utils/propTypes'
 
+import CurrentTimeIndicator from './CurrentTimeIndicator'
 import DayColumnWrapper from './DayColumnWrapper'
 
 class DayColumn extends React.Component {
@@ -124,6 +125,9 @@ class DayColumn extends React.Component {
 
     const { className, style } = dayProp(max)
 
+    const CurrentTimeIndicatorComponent =
+      components.currentTimeIndicator || CurrentTimeIndicator
+
     const DayColumnWrapperComponent =
       components.dayColumnWrapper || DayColumnWrapper
 
@@ -173,9 +177,8 @@ class DayColumn extends React.Component {
           </div>
         )}
         {isNow && this.intervalTriggered && (
-          <div
-            className="rbc-current-time-indicator"
-            style={{ top: `${this.state.timeIndicatorPosition}%` }}
+          <CurrentTimeIndicatorComponent
+            position={this.state.timeIndicatorPosition}
           />
         )}
       </DayColumnWrapperComponent>


### PR DESCRIPTION
To improve the user experience of calendars we want to be able to customise the appearance of the current time indicator that is rendered over the `DayColumn`. Rather than hard-coding an improved appearance, a more flexible approach would be to extend the `Calendar`'s `components` props to include a `currentTimeIndicator` component for full control downstream.

Note that the existing implementation of the current time indicator is maintained and defaulted to if no custom implementation is provided:

![image](https://user-images.githubusercontent.com/6977616/168641006-33f75409-78e0-4211-8a9b-19c829533feb.png)