### PR TITLE
 fix: make semantic release work for chore commits 

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,6 +1,11 @@
 name: Release
 
-on: workflow_dispatch
+on:
+    workflow_dispatch:
+    push:
+        branches:
+          - main
+          - master
 
 jobs:
   release:

--- a/release.config.js
+++ b/release.config.js
@@ -6,7 +6,12 @@
 module.exports = {
   branches: ['master'],
   plugins: [
-    '@semantic-release/commit-analyzer',
+    [
+      '@semantic-release/commit-analyzer',
+      {
+        releaseRules: [{ type: 'chore', release: 'patch' }],
+      },
+    ],
     '@semantic-release/release-notes-generator',
     [
       '@semantic-release/changelog',


### PR DESCRIPTION
- Release on merging to main automatically
- Stop the CI from ignoring `chore`